### PR TITLE
Render favorites

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::FavoritesController < ApplicationController
   def create
-    favorite = Favorite.new(favorite_params)
+    fav_city = City.find(params[:city_id])
+    favorite = favorite_creator(fav_city)
     if favorite.save
       render json: FavoriteSerializer.new(favorite).serializable_hash.to_json, status: 201
     else
@@ -13,7 +14,7 @@ class Api::V1::FavoritesController < ApplicationController
 
   private
 
-  def favorite_params
-    params.require(:favorite).permit(:user_id, :city_id, :city_name, :state, :summary, :total_score, :categories_hash_array)
+  def favorite_creator(city)
+    Favorite.new(user_id: params[:user_id], city_id: params[:city_id], city_name: city.city, state: city.state, summary: city.summary, total_score: city.total_score, categories_hash_array: city.categories_hash_array)
   end
 end

--- a/spec/requests/favorites_request_spec.rb
+++ b/spec/requests/favorites_request_spec.rb
@@ -25,17 +25,7 @@ RSpec.describe 'Favorites Requests' do
     it 'can create a favorite' do
       user_id = create(:user).id
       city_id = create(:city).id
-      favorite_params = {
-        user_id: user_id,
-        city_id: city_id,
-        city_name: 'Denver',
-        state: 'Colorado',
-        summary: 'It is a good place',
-        total_score: 55.55, 
-        categories_hash_array: @categories_array
-      }
-      headers = { "CONTENT_TYPE" => "application/json"}
-      post '/api/v1/favorites', headers: headers, params: JSON.generate(favorite: favorite_params)
+      post "/api/v1/favorites?user_id=#{user_id}&city_id=#{city_id}"
       created_favorite = Favorite.last
 
       expect(response.status).to eq 201
@@ -46,28 +36,17 @@ RSpec.describe 'Favorites Requests' do
     it 'serializes favorite data' do
       user_id = create(:user).id
       city_id = create(:city).id
-      favorite_params = {
-        user_id: user_id,
-        city_id: city_id,
-        city_name: 'Denver',
-        state: 'Colorado',
-        summary: 'It is a good place',
-        total_score: 55.55, 
-        categories_hash_array: @categories_array
-      }
-      headers = { "CONTENT_TYPE" => "application/json"}
-      post '/api/v1/favorites', headers: headers, params: JSON.generate(favorite: favorite_params)
+      post "/api/v1/favorites?user_id=#{user_id}&city_id=#{city_id}"
 
       fav = JSON.parse(response.body, symbolize_names: true)
-      fav = fav[:data][:attributes]
 
       expect(fav[:user_id]).is_a? Integer
       expect(fav[:city_id]).is_a? Integer
-      expect(fav[:city_name]).to eq 'Denver'
-      expect(fav[:state]).to eq 'Colorado'
-      expect(fav[:summary]).to eq 'It is a good place'
-      expect(fav[:total_score]).to eq 55.55
-      expect(fav[:categories_hash_array]).to eq @categories_array
+      expect(fav[:city_name]).is_a? String
+      expect(fav[:state]).is_a? String
+      expect(fav[:summary]).is_a? String
+      expect(fav[:total_score]).is_a? Float
+      expect(fav[:categories_hash_array]).is_a? Array
     end
 
   end

--- a/spec/requests/favorites_request_spec.rb
+++ b/spec/requests/favorites_request_spec.rb
@@ -2,26 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Favorites Requests' do
   describe '#create' do
-    before(:each) do
-      @categories_array = '[{:name=>"Housing", :score_out_of_10=>3.8375},
-    {:name=>"Cost of Living", :score_out_of_10=>5.102},
-    {:name=>"Startups", :score_out_of_10=>7.8645},
-    {:name=>"Venture Capital", :score_out_of_10=>6.117},
-    {:name=>"Travel Connectivity", :score_out_of_10=>4.243},
-    {:name=>"Commute", :score_out_of_10=>4.530000000000001},
-    {:name=>"Business Freedom", :score_out_of_10=>8.671},
-    {:name=>"Safety", :score_out_of_10=>5.371},
-    {:name=>"Healthcare", :score_out_of_10=>8.615666666666666},
-    {:name=>"Education", :score_out_of_10=>3.6245},
-    {:name=>"Environmental Quality", :score_out_of_10=>7.11675},
-    {:name=>"Economy", :score_out_of_10=>6.5145},
-    {:name=>"Taxation", :score_out_of_10=>4.346},
-    {:name=>"Internet Access", :score_out_of_10=>5.418500000000001},
-    {:name=>"Leisure & Culture", :score_out_of_10=>6.2235},
-    {:name=>"Tolerance", :score_out_of_10=>7.860499999999999},
-    {:name=>"Outdoors", :score_out_of_10=>7.932999999999999}]'
-    end
-
     it 'can create a favorite' do
       user_id = create(:user).id
       city_id = create(:city).id
@@ -37,7 +17,6 @@ RSpec.describe 'Favorites Requests' do
       user_id = create(:user).id
       city_id = create(:city).id
       post "/api/v1/favorites?user_id=#{user_id}&city_id=#{city_id}"
-
       fav = JSON.parse(response.body, symbolize_names: true)
 
       expect(fav[:user_id]).is_a? Integer
@@ -48,6 +27,5 @@ RSpec.describe 'Favorites Requests' do
       expect(fav[:total_score]).is_a? Float
       expect(fav[:categories_hash_array]).is_a? Array
     end
-
   end
 end


### PR DESCRIPTION
This will accept a post request from FE with query params `user_id` and `city_id`. Will render a Favorite object back in JSON with full city details. 

Json object HAS ONE NAMING DIFFERENCE. City column is rendered as `city_name` to work around an AR error. 
